### PR TITLE
Change Dockerfile to use multi-stage builds.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.10
+
+FROM golang:1.10 as buildimage
 
 LABEL org.label-schema.version=latest
 LABEL org.label-schema.vcs-url="https://github.com/ortuman/jackal.git"
@@ -16,10 +17,15 @@ RUN chmod +x $GOPATH/bin/dep
 RUN go get -d github.com/ortuman/jackal
 
 RUN cd $GOPATH/src/github.com/ortuman/jackal && dep ensure
+RUN export CGO_ENABLED=0
+RUN export GOOS=linux
+RUN export GOARCH=amd64
 RUN go build github.com/ortuman/jackal
 
+FROM debian:stretch-slim
+RUN apt-get update
+RUN apt-get install -y --no-install-recommends libidn11-dev
+COPY --from=buildimage /jackal/jackal /
 ADD docker.jackal.yml /etc/jackal/jackal.yml
-
 EXPOSE 5222
-
-ENTRYPOINT ["/jackal/jackal"]
+CMD ["./jackal"]


### PR DESCRIPTION
New version, which also uses debiah:stretch-slim, has image size of 130MB compared to the original at 417MB (~70% reduction in size).

This could likely be reduced further by using Alpine Linux, and further still by compiling everything statically and using the scratch image, but cutting the image size by 70% is a good start.