### PR TITLE
sqlmock is only needed in tests

### DIFF
--- a/storage/sql/sql.go
+++ b/storage/sql/sql.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/DATA-DOG/go-sqlmock"
 	sq "github.com/Masterminds/squirrel"
 	_ "github.com/go-sql-driver/mysql" // SQL driver
 	"github.com/ortuman/jackal/log"
@@ -72,20 +71,6 @@ func New(cfg *Config) *Storage {
 	go s.loop()
 
 	return s
-}
-
-// NewMock returns a mocked SQL storage instance.
-func NewMock() (*Storage, sqlmock.Sqlmock) {
-	var err error
-	var sqlMock sqlmock.Sqlmock
-	s := &Storage{
-		pool: pool.NewBufferPool(),
-	}
-	s.db, sqlMock, err = sqlmock.New()
-	if err != nil {
-		log.Fatalf("%v", err)
-	}
-	return s, sqlMock
 }
 
 // Close shuts down SQL storage sub system.

--- a/storage/sql/sql_test.go
+++ b/storage/sql/sql_test.go
@@ -7,8 +7,26 @@ package sql
 
 import (
 	"errors"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/ortuman/jackal/log"
+	"github.com/ortuman/jackal/pool"
 )
 
 var (
 	errMySQLStorage = errors.New("MySQL storage error")
 )
+
+// NewMock returns a mocked SQL storage instance.
+func NewMock() (*Storage, sqlmock.Sqlmock) {
+	var err error
+	var sqlMock sqlmock.Sqlmock
+	s := &Storage{
+		pool: pool.NewBufferPool(),
+	}
+	s.db, sqlMock, err = sqlmock.New()
+	if err != nil {
+		log.Fatalf("%v", err)
+	}
+	return s, sqlMock
+}


### PR DESCRIPTION
Mocking is only needed in tests. This PR makes sure it's can't be used by third parties (that aren't also building tests) or the main application. It is left exported because it appears that other test packages import this one for this function.