### PR TITLE
Support for PostgreSQL

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect
 	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
 	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
-	github.com/lib/pq v1.0.0 // indirect
+	github.com/lib/pq v1.0.0
 	github.com/mattn/go-sqlite3 v1.10.0 // indirect
 	github.com/miekg/dns v1.0.15 // indirect
 	github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c // indirect

--- a/sql/postgres.sql
+++ b/sql/postgres.sql
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2018 robzon.
+ * See the LICENSE file for more information.
+ */
+
+CREATE TABLE IF NOT EXISTS users (
+    username            VARCHAR(256) PRIMARY KEY,
+    password            TEXT NOT NULL,
+    last_presence       TEXT NOT NULL,
+    last_presence_at    TIMESTAMP NOT NULL,
+    updated_at          TIMESTAMP NOT NULL,
+    created_at          TIMESTAMP NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS roster_notifications (
+    contact     VARCHAR(256) NOT NULL,
+    jid         VARCHAR(512) NOT NULL,
+    elements    TEXT NOT NULL,
+    updated_at  TIMESTAMP NOT NULL,
+    created_at  TIMESTAMP NOT NULL,
+
+    PRIMARY KEY (contact, jid)
+);
+
+CREATE INDEX IF NOT EXISTS i_roster_notifications_jid ON roster_notifications(jid);
+
+CREATE TABLE IF NOT EXISTS roster_items (
+    username        VARCHAR(256) NOT NULL,
+    jid             VARCHAR(512) NOT NULL,
+    name            TEXT NOT NULL,
+    subscription    TEXT NOT NULL,
+    groups          TEXT NOT NULL,
+    ask BOOL        NOT NULL,
+    ver             INT NOT NULL DEFAULT 0,
+    updated_at      TIMESTAMP NOT NULL,
+    created_at      TIMESTAMP NOT NULL,
+    
+    PRIMARY KEY (username, jid)
+);
+
+CREATE INDEX IF NOT EXISTS i_roster_items_username ON roster_items(username);
+CREATE INDEX IF NOT EXISTS i_roster_items_jid ON roster_items(jid);
+
+CREATE TABLE IF NOT EXISTS roster_versions (
+    username            VARCHAR(256) NOT NULL,
+    ver                 INT NOT NULL DEFAULT 0,
+    last_deletion_ver   INT NOT NULL DEFAULT 0,
+    updated_at          TIMESTAMP NOT NULL,
+    created_at          TIMESTAMP NOT NULL,
+    
+    PRIMARY KEY (username)
+);
+
+CREATE TABLE IF NOT EXISTS blocklist_items (
+    username        VARCHAR(256) NOT NULL,
+    jid             VARCHAR(512) NOT NULL,
+    created_at      TIMESTAMP NOT NULL,
+    
+    PRIMARY KEY(username, jid)
+);
+
+CREATE INDEX IF NOT EXISTS i_blocklist_items_username ON blocklist_items(username);
+
+CREATE TABLE IF NOT EXISTS private_storage (
+    username        VARCHAR(256) NOT NULL,
+    namespace       VARCHAR(512) NOT NULL,
+    data            TEXT NOT NULL,
+    updated_at      TIMESTAMP NOT NULL,
+    created_at      TIMESTAMP NOT NULL,
+    
+    PRIMARY KEY (username, namespace)
+);
+
+CREATE INDEX IF NOT EXISTS i_private_storage_username ON private_storage(username);
+
+CREATE TABLE IF NOT EXISTS vcards (
+    username        VARCHAR(256) PRIMARY KEY,
+    vcard           TEXT NOT NULL,
+    updated_at      TIMESTAMP NOT NULL,
+    created_at      TIMESTAMP NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS offline_messages (
+    username        VARCHAR(256) NOT NULL,
+    data            TEXT NOT NULL,
+    created_at      TIMESTAMP NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS i_offline_messages_username ON offline_messages(username);

--- a/storage/sql/block_list.go
+++ b/storage/sql/block_list.go
@@ -17,11 +17,17 @@ import (
 func (s *Storage) InsertBlockListItems(items []model.BlockListItem) error {
 	return s.inTransaction(func(tx *sql.Tx) error {
 		for _, item := range items {
-			_, err := sq.Insert("blocklist_items").
-				Options("IGNORE").
+			q := sq.Insert("blocklist_items").
 				Columns("username", "jid", "created_at").
 				Values(item.Username, item.JID, nowExpr).
-				RunWith(tx).Exec()
+				RunWith(tx)
+
+			if s.engine == "mysql" {
+				q = q.Options("IGNORE")
+			}
+
+			_, err := q.Exec()
+
 			if err != nil {
 				return err
 			}

--- a/storage/sql/sql_test.go
+++ b/storage/sql/sql_test.go
@@ -22,7 +22,8 @@ func NewMock() (*Storage, sqlmock.Sqlmock) {
 	var err error
 	var sqlMock sqlmock.Sqlmock
 	s := &Storage{
-		pool: pool.NewBufferPool(),
+		engine: "mysql",
+		pool:   pool.NewBufferPool(),
 	}
 	s.db, sqlMock, err = sqlmock.New()
 	if err != nil {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -241,7 +241,9 @@ func New(config *Config) (Storage, error) {
 	case BadgerDB:
 		return badgerdb.New(config.BadgerDB), nil
 	case MySQL:
-		return sql.New(config.MySQL), nil
+		return sql.New("mysql", config.MySQL), nil
+	case PostgreSQL:
+		return sql.New("postgresql", config.PostgreSQL), nil
 	case Memory:
 		return memstorage.New(), nil
 	default:


### PR DESCRIPTION
This makes jackal work with PostgreSQL, but it's far from perfect. It's a bunch of switch statements in places where database-specific queries are needed. While this should be ok-ish for now, I see a need for a bigger overhaul of the storage code to better support multiple database engines. I'd be happy to discuss and work on this some more.