### PR TITLE
Fix build rule in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ fmt: install-tools
 
 build:
 	@echo "Building binary..."
-	@export go build -ldflags="-s -w"
+	@go build -ldflags="-s -w"
 
 test:
 	@echo "Running tests..."


### PR DESCRIPTION
It appears that it previously exported `GO111MODULE` which was removed incompletely in 0be04da136cad985557330f6a6e8cf4ebbcc32a5.