### PR TITLE
Remove non-standard SCRAM-SHA-512 auth mechanism

### DIFF
--- a/auth/scram.go
+++ b/auth/scram.go
@@ -12,7 +12,6 @@ import (
 	"crypto/rand"
 	"crypto/sha1"
 	"crypto/sha256"
-	"crypto/sha512"
 	"encoding/base64"
 	"fmt"
 	"hash"
@@ -37,9 +36,6 @@ const (
 
 	// ScramSHA256 represents SCRAM-SHA-256 authentication method.
 	ScramSHA256
-
-	// ScramSHA512 represents SCRAM-SHA-512 authentication method.
-	ScramSHA512
 )
 
 const iterationsCount = 4096
@@ -118,9 +114,6 @@ func NewScram(stm stream.C2S, tr transport.Transport, scramType ScramType, usesC
 	case ScramSHA256:
 		s.h = sha256.New
 		s.hKeyLen = sha256.Size
-	case ScramSHA512:
-		s.h = sha512.New
-		s.hKeyLen = sha512.Size
 	}
 	return s
 }
@@ -139,12 +132,6 @@ func (s *Scram) Mechanism() string {
 			return "SCRAM-SHA-256-PLUS"
 		}
 		return "SCRAM-SHA-256"
-
-	case ScramSHA512:
-		if s.usesCb {
-			return "SCRAM-SHA-512-PLUS"
-		}
-		return "SCRAM-SHA-512"
 	}
 	return ""
 }

--- a/auth/scram_test.go
+++ b/auth/scram_test.go
@@ -11,7 +11,6 @@ import (
 	"crypto/hmac"
 	"crypto/sha1"
 	"crypto/sha256"
-	"crypto/sha512"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
@@ -101,18 +100,8 @@ var tt = []scramAuthTestCase{
 		password:    "1234",
 	},
 	{
-		// SCRAM-SHA-512
-		id:          3,
-		scramType:   ScramSHA512,
-		usesCb:      false,
-		gs2BindFlag: "n",
-		n:           "ortuman",
-		r:           "6d805d99-6dc3-4e5a-9a68-653856fc5129",
-		password:    "1234",
-	},
-	{
 		// SCRAM-SHA-1-PLUS
-		id:          4,
+		id:          3,
 		scramType:   ScramSHA1,
 		usesCb:      true,
 		cbBytes:     randomBytes(23),
@@ -124,20 +113,8 @@ var tt = []scramAuthTestCase{
 	},
 	{
 		// SCRAM-SHA-256-PLUS
-		id:          5,
+		id:          4,
 		scramType:   ScramSHA256,
-		usesCb:      true,
-		cbBytes:     randomBytes(32),
-		gs2BindFlag: "p=tls-unique",
-		authID:      "a=jackal.im",
-		n:           "ortuman",
-		r:           "d712875c-bd3b-4b41-801d-eb9c541d9884",
-		password:    "1234",
-	},
-	{
-		// SCRAM-SHA-512-PLUS
-		id:          6,
-		scramType:   ScramSHA512,
 		usesCb:      true,
 		cbBytes:     randomBytes(32),
 		gs2BindFlag: "p=tls-unique",
@@ -150,7 +127,7 @@ var tt = []scramAuthTestCase{
 	// Fail cases
 	{
 		// invalid user
-		id:          7,
+		id:          5,
 		scramType:   ScramSHA1,
 		usesCb:      false,
 		gs2BindFlag: "n",
@@ -161,7 +138,7 @@ var tt = []scramAuthTestCase{
 	},
 	{
 		// invalid password
-		id:          8,
+		id:          6,
 		scramType:   ScramSHA1,
 		usesCb:      false,
 		gs2BindFlag: "n",
@@ -172,7 +149,7 @@ var tt = []scramAuthTestCase{
 	},
 	{
 		// not authorized gs2BindFlag
-		id:          9,
+		id:          7,
 		scramType:   ScramSHA1,
 		usesCb:      false,
 		gs2BindFlag: "y",
@@ -183,7 +160,7 @@ var tt = []scramAuthTestCase{
 	},
 	{
 		// invalid authID
-		id:          10,
+		id:          8,
 		scramType:   ScramSHA1,
 		usesCb:      false,
 		gs2BindFlag: "n",
@@ -195,7 +172,7 @@ var tt = []scramAuthTestCase{
 	},
 	{
 		// not matching gs2BindFlag
-		id:          11,
+		id:          9,
 		scramType:   ScramSHA1,
 		usesCb:      false,
 		gs2BindFlag: "p=tls-unique",
@@ -207,7 +184,7 @@ var tt = []scramAuthTestCase{
 	},
 	{
 		// not matching gs2BindFlag
-		id:          12,
+		id:          10,
 		scramType:   ScramSHA1,
 		usesCb:      false,
 		gs2BindFlag: "q=tls-unique",
@@ -219,7 +196,7 @@ var tt = []scramAuthTestCase{
 	},
 	{
 		// empty username
-		id:          13,
+		id:          11,
 		scramType:   ScramSHA1,
 		usesCb:      false,
 		gs2BindFlag: "n",
@@ -251,16 +228,8 @@ func TestScramMechanisms(t *testing.T) {
 	require.Equal(t, authr4.Mechanism(), "SCRAM-SHA-256-PLUS")
 	require.True(t, authr4.UsesChannelBinding())
 
-	authr5 := NewScram(testStm, testTr, ScramSHA512, false, s)
-	require.Equal(t, authr5.Mechanism(), "SCRAM-SHA-512")
-	require.False(t, authr5.UsesChannelBinding())
-
-	authr6 := NewScram(testStm, testTr, ScramSHA512, true, s)
-	require.Equal(t, authr6.Mechanism(), "SCRAM-SHA-512-PLUS")
-	require.True(t, authr6.UsesChannelBinding())
-
-	authr7 := NewScram(testStm, testTr, ScramType(99), true, s)
-	require.Equal(t, authr7.Mechanism(), "")
+	authr5 := NewScram(testStm, testTr, ScramType(99), true, s)
+	require.Equal(t, authr5.Mechanism(), "")
 }
 
 func TestScramBadPayload(t *testing.T) {
@@ -400,8 +369,6 @@ func testScramAuthPbkdf2(b []byte, salt []byte, scramType ScramType, iterationCo
 		return pbkdf2.Key(b, salt, iterationCount, sha1.Size, sha1.New)
 	case ScramSHA256:
 		return pbkdf2.Key(b, salt, iterationCount, sha256.Size, sha256.New)
-	case ScramSHA512:
-		return pbkdf2.Key(b, salt, iterationCount, sha512.Size, sha512.New)
 	}
 	return nil
 }
@@ -413,8 +380,6 @@ func testScramAuthHmac(b []byte, key []byte, scramType ScramType) []byte {
 		h = sha1.New
 	case ScramSHA256:
 		h = sha256.New
-	case ScramSHA512:
-		h = sha512.New
 	}
 	m := hmac.New(h, key)
 	m.Write(b)
@@ -428,8 +393,6 @@ func testScramAuthHash(b []byte, scramType ScramType) []byte {
 		h = sha1.New()
 	case ScramSHA256:
 		h = sha256.New()
-	case ScramSHA512:
-		h = sha512.New()
 	}
 	h.Write(b)
 	return h.Sum(nil)

--- a/c2s/in.go
+++ b/c2s/in.go
@@ -207,12 +207,6 @@ func (s *inStream) initializeAuthenticators() {
 			if hasChannelBinding {
 				authenticators = append(authenticators, auth.NewScram(s, tr, auth.ScramSHA256, true, s.userRep))
 			}
-
-		case "scram_sha_512":
-			authenticators = append(authenticators, auth.NewScram(s, tr, auth.ScramSHA512, false, s.userRep))
-			if hasChannelBinding {
-				authenticators = append(authenticators, auth.NewScram(s, tr, auth.ScramSHA512, true, s.userRep))
-			}
 		}
 	}
 	s.authenticators = authenticators

--- a/example.jackal.yml
+++ b/example.jackal.yml
@@ -90,7 +90,6 @@ c2s:
       - digest_md5
       - scram_sha_1
       - scram_sha_256
-      - scram_sha_512
 
 s2s:
     dial_timeout: 15

--- a/example.jackal.yml
+++ b/example.jackal.yml
@@ -87,7 +87,6 @@ c2s:
 
     sasl:
       - plain
-      - digest_md5
       - scram_sha_1
       - scram_sha_256
 


### PR DESCRIPTION
While looking into Jackal's auth code I noticed that it supports a SASL
mechanism called SCRAM-SHA-512. There is no such mechanism currently
standardized by the IETF, and it is not a mechanism supported by any
XMPP clients that I am aware of. Because the hash is only used as part
of an HMAC, there are no known security issues at this time with
SCRAM-SHA-1 or SCRAM-SHA-256, and no known benefit to using SHA-512 as
the hash. Furthermore, if the IETF were to standardize a mechanism
called SCRAM-SHA-512 in the future and it were somehow incompatible with
this one, it could be hard to ensure the two were compatible later and
Jackal may be stuck with no upgrade path and no way to tell which
mechanism a client was requesting (the IETF version of SCRAM-SHA-512, or the Jackal version).

Fixes #107