### PR TITLE
Store salted and hashed passwords in the database

### DIFF
--- a/auth/scram_test.go
+++ b/auth/scram_test.go
@@ -210,7 +210,15 @@ var tt = []scramAuthTestCase{
 
 func TestScramMechanisms(t *testing.T) {
 	testTr := &fakeTransport{}
-	testStm, s := authTestSetup(&model.User{Username: "ortuman", Password: "1234"})
+	passwordScramSHA1 := SaltedPassword([]byte(password), []byte(salt), iterationCount, sha1.New)
+	passwordScramSHA256 := SaltedPassword([]byte(password), []byte(salt), iterationCount, sha256.New)
+	testStm, s := authTestSetup(&model.User{
+		Username:            "ortuman",
+		PasswordScramSHA1:   passwordScramSHA1,
+		PasswordScramSHA256: passwordScramSHA256,
+		Salt:                []byte(salt),
+		IterationCount:      iterationCount,
+	})
 
 	authr := NewScram(testStm, testTr, ScramSHA1, false, s)
 	require.Equal(t, authr.Mechanism(), "SCRAM-SHA-1")
@@ -234,7 +242,13 @@ func TestScramMechanisms(t *testing.T) {
 
 func TestScramBadPayload(t *testing.T) {
 	testTr := &fakeTransport{}
-	testStm, s := authTestSetup(&model.User{Username: "ortuman", Password: "1234"})
+	passwordScramSHA1 := SaltedPassword([]byte(password), []byte(salt), iterationCount, sha1.New)
+	testStm, s := authTestSetup(&model.User{
+		Username:          "ortuman",
+		PasswordScramSHA1: passwordScramSHA1,
+		Salt:              []byte(salt),
+		IterationCount:    iterationCount,
+	})
 
 	authr := NewScram(testStm, testTr, ScramSHA1, false, s)
 
@@ -265,7 +279,15 @@ func processScramTestCase(t *testing.T, tc *scramAuthTestCase) error {
 	if tc.usesCb {
 		tr.cbBytes = tc.cbBytes
 	}
-	testStm, s := authTestSetup(&model.User{Username: "ortuman", Password: "1234"})
+	passwordScramSHA1 := SaltedPassword([]byte(password), []byte(salt), iterationCount, sha1.New)
+	passwordScramSHA256 := SaltedPassword([]byte(password), []byte(salt), iterationCount, sha256.New)
+	testStm, s := authTestSetup(&model.User{
+		Username:            "ortuman",
+		PasswordScramSHA1:   passwordScramSHA1,
+		PasswordScramSHA256: passwordScramSHA256,
+		Salt:                []byte(salt),
+		IterationCount:      iterationCount,
+	})
 
 	authr := NewScram(testStm, tr, tc.scramType, tc.usesCb, s)
 

--- a/c2s/in_test.go
+++ b/c2s/in_test.go
@@ -7,10 +7,13 @@ package c2s
 
 import (
 	"context"
+	"crypto/sha1"
+	"crypto/sha256"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/ortuman/jackal/auth"
 	"github.com/ortuman/jackal/component"
 	"github.com/ortuman/jackal/model"
 	"github.com/ortuman/jackal/module"
@@ -24,6 +27,23 @@ import (
 	"github.com/ortuman/jackal/xmpp/jid"
 	"github.com/stretchr/testify/require"
 )
+
+func newUser() *model.User {
+	const (
+		password       = "pencil"
+		iterationCount = 1
+		salt           = "salt"
+	)
+	passwordScramSHA1 := auth.SaltedPassword([]byte(password), []byte(salt), iterationCount, sha1.New)
+	passwordScramSHA256 := auth.SaltedPassword([]byte(password), []byte(salt), iterationCount, sha256.New)
+	return &model.User{
+		Username:            "user",
+		PasswordScramSHA1:   passwordScramSHA1,
+		PasswordScramSHA256: passwordScramSHA256,
+		Salt:                []byte(salt),
+		IterationCount:      iterationCount,
+	}
+}
 
 func TestStream_ConnectTimeout(t *testing.T) {
 	r, userRep, blockListRep := setupTest("localhost")
@@ -76,7 +96,7 @@ func TestStream_Features(t *testing.T) {
 func TestStream_TLS(t *testing.T) {
 	r, userRep, blockListRep := setupTest("localhost")
 
-	_ = userRep.UpsertUser(context.Background(), &model.User{Username: "user", Password: "pencil"})
+	_ = userRep.UpsertUser(context.Background(), newUser())
 
 	stm, conn := tUtilStreamInit(r, userRep, blockListRep)
 	tUtilStreamOpen(conn)
@@ -97,7 +117,7 @@ func TestStream_TLS(t *testing.T) {
 func TestStream_FailAuthenticate(t *testing.T) {
 	r, userRep, blockListRep := setupTest("localhost")
 
-	_ = userRep.UpsertUser(context.Background(), &model.User{Username: "user", Password: "pencil"})
+	_ = userRep.UpsertUser(context.Background(), newUser())
 
 	_, conn := tUtilStreamInit(r, userRep, blockListRep)
 	tUtilStreamOpen(conn)
@@ -131,7 +151,7 @@ func TestStream_FailAuthenticate(t *testing.T) {
 func TestStream_Compression(t *testing.T) {
 	r, userRep, blockListRep := setupTest("localhost")
 
-	_ = userRep.UpsertUser(context.Background(), &model.User{Username: "user", Password: "pencil"})
+	_ = userRep.UpsertUser(context.Background(), newUser())
 
 	stm, conn := tUtilStreamInit(r, userRep, blockListRep)
 	tUtilStreamOpen(conn)
@@ -175,7 +195,7 @@ func TestStream_Compression(t *testing.T) {
 func TestStream_StartSession(t *testing.T) {
 	r, userRep, blockListRep := setupTest("localhost")
 
-	_ = userRep.UpsertUser(context.Background(), &model.User{Username: "user", Password: "pencil"})
+	_ = userRep.UpsertUser(context.Background(), newUser())
 
 	stm, conn := tUtilStreamInit(r, userRep, blockListRep)
 	tUtilStreamOpen(conn)
@@ -197,7 +217,7 @@ func TestStream_StartSession(t *testing.T) {
 func TestStream_SendIQ(t *testing.T) {
 	r, userRep, blockListRep := setupTest("localhost")
 
-	_ = userRep.UpsertUser(context.Background(), &model.User{Username: "user", Password: "pencil"})
+	_ = userRep.UpsertUser(context.Background(), newUser())
 
 	stm, conn := tUtilStreamInit(r, userRep, blockListRep)
 	tUtilStreamOpen(conn)
@@ -234,7 +254,7 @@ func TestStream_SendIQ(t *testing.T) {
 func TestStream_SendPresence(t *testing.T) {
 	r, userRep, blockListRep := setupTest("localhost")
 
-	_ = userRep.UpsertUser(context.Background(), &model.User{Username: "user", Password: "pencil"})
+	_ = userRep.UpsertUser(context.Background(), newUser())
 
 	stm, conn := tUtilStreamInit(r, userRep, blockListRep)
 	tUtilStreamOpen(conn)
@@ -278,7 +298,7 @@ func TestStream_SendPresence(t *testing.T) {
 func TestStream_SendMessage(t *testing.T) {
 	r, userRep, blockListRep := setupTest("localhost")
 
-	_ = userRep.UpsertUser(context.Background(), &model.User{Username: "user", Password: "pencil"})
+	_ = userRep.UpsertUser(context.Background(), newUser())
 
 	stm, conn := tUtilStreamInit(r, userRep, blockListRep)
 	tUtilStreamOpen(conn)
@@ -330,7 +350,7 @@ func TestStream_SendMessage(t *testing.T) {
 func TestStream_SendToBlockedJID(t *testing.T) {
 	r, userRep, blockListRep := setupTest("localhost")
 
-	_ = userRep.UpsertUser(context.Background(), &model.User{Username: "user", Password: "pencil"})
+	_ = userRep.UpsertUser(context.Background(), newUser())
 
 	stm, conn := tUtilStreamInit(r, userRep, blockListRep)
 	tUtilStreamOpen(conn)

--- a/model/user.go
+++ b/model/user.go
@@ -15,10 +15,13 @@ import (
 
 // User represents a user storage entity.
 type User struct {
-	Username       string
-	Password       string
-	LastPresence   *xmpp.Presence
-	LastPresenceAt time.Time
+	Username            string
+	PasswordScramSHA1   []byte
+	PasswordScramSHA256 []byte
+	Salt                []byte
+	IterationCount      int
+	LastPresence        *xmpp.Presence
+	LastPresenceAt      time.Time
 }
 
 // FromBytes deserializes a User entity from it's gob binary representation.
@@ -27,7 +30,16 @@ func (u *User) FromBytes(buf *bytes.Buffer) error {
 	if err := dec.Decode(&u.Username); err != nil {
 		return err
 	}
-	if err := dec.Decode(&u.Password); err != nil {
+	if err := dec.Decode(&u.PasswordScramSHA1); err != nil {
+		return err
+	}
+	if err := dec.Decode(&u.PasswordScramSHA256); err != nil {
+		return err
+	}
+	if err := dec.Decode(&u.Salt); err != nil {
+		return err
+	}
+	if err := dec.Decode(&u.IterationCount); err != nil {
 		return err
 	}
 	var hasPresence bool
@@ -53,7 +65,16 @@ func (u *User) ToBytes(buf *bytes.Buffer) error {
 	if err := enc.Encode(&u.Username); err != nil {
 		return err
 	}
-	if err := enc.Encode(&u.Password); err != nil {
+	if err := enc.Encode(&u.PasswordScramSHA1); err != nil {
+		return err
+	}
+	if err := enc.Encode(&u.PasswordScramSHA256); err != nil {
+		return err
+	}
+	if err := enc.Encode(&u.Salt); err != nil {
+		return err
+	}
+	if err := enc.Encode(&u.IterationCount); err != nil {
 		return err
 	}
 	hasPresence := u.LastPresence != nil

--- a/model/user_test.go
+++ b/model/user_test.go
@@ -22,7 +22,10 @@ func TestModelUser(t *testing.T) {
 	j2, _ := jid.NewWithString("ortuman@jackal.im", true)
 
 	usr1.Username = "ortuman"
-	usr1.Password = "1234"
+	usr1.PasswordScramSHA1 = []byte("sha1")
+	usr1.PasswordScramSHA256 = []byte("sha256")
+	usr1.Salt = []byte("salt")
+	usr1.IterationCount = 10000
 	usr1.LastPresence = xmpp.NewPresence(j1, j2, xmpp.AvailableType)
 
 	buf := new(bytes.Buffer)
@@ -30,7 +33,10 @@ func TestModelUser(t *testing.T) {
 	usr2 := User{}
 	require.Nil(t, usr2.FromBytes(buf))
 	require.Equal(t, usr1.Username, usr2.Username)
-	require.Equal(t, usr1.Password, usr2.Password)
+	require.Equal(t, usr1.PasswordScramSHA1, usr2.PasswordScramSHA1)
+	require.Equal(t, usr1.PasswordScramSHA256, usr2.PasswordScramSHA256)
+	require.Equal(t, usr1.Salt, usr2.Salt)
+	require.Equal(t, usr1.IterationCount, usr2.IterationCount)
 	require.Equal(t, usr1.LastPresence.String(), usr2.LastPresence.String())
 	require.NotEqual(t, time.Time{}, usr2.LastPresenceAt)
 }

--- a/module/roster/roster.go
+++ b/module/roster/roster.go
@@ -679,9 +679,12 @@ func (x *Roster) broadcastPresence(ctx context.Context, presence *xmpp.Presence)
 		return err
 	} else if usr != nil {
 		return x.userRep.UpsertUser(ctx, &model.User{
-			Username:     usr.Username,
-			Password:     usr.Password,
-			LastPresence: presence,
+			Username:            usr.Username,
+			PasswordScramSHA1:   usr.PasswordScramSHA1,
+			PasswordScramSHA256: usr.PasswordScramSHA256,
+			Salt:                usr.Salt,
+			IterationCount:      usr.IterationCount,
+			LastPresence:        presence,
 		})
 	}
 	return nil

--- a/sql/mysql.up.sql
+++ b/sql/mysql.up.sql
@@ -6,12 +6,15 @@
 -- users
 
 CREATE TABLE IF NOT EXISTS users (
-    username         VARCHAR(256) PRIMARY KEY,
-    password         TEXT NOT NULL,
-    last_presence    TEXT NOT NULL,
-    last_presence_at DATETIME NOT NULL,
-    updated_at       DATETIME NOT NULL,
-    created_at       DATETIME NOT NULL
+    username              VARCHAR(256) PRIMARY KEY,
+    password_scram_sha1   BLOB NOT NULL,
+    password_scram_sha256 BLOB NOT NULL,
+    salt                  BLOB NOT NULL,
+    iteration_count       INTEGER NOT NULL,
+    last_presence         TEXT NOT NULL,
+    last_presence_at      DATETIME NOT NULL,
+    updated_at            DATETIME NOT NULL,
+    created_at            DATETIME NOT NULL
 ) ENGINE=InnoDB CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 -- presences

--- a/sql/postgres.up.psql
+++ b/sql/postgres.up.psql
@@ -35,12 +35,15 @@ $$ LANGUAGE plpgsql;
 -- users
 
 CREATE TABLE IF NOT EXISTS users (
-    username            VARCHAR(1023) PRIMARY KEY,
-    password            TEXT NOT NULL,
-    last_presence       TEXT NOT NULL,
-    last_presence_at    TIMESTAMP WITH TIME ZONE NOT NULL,
-    updated_at          TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
-    created_at          TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+    username              VARCHAR(1023) PRIMARY KEY,
+    password_scram_sha1   BYTEA NOT NULL,
+    password_scram_sha256 BYTEA NOT NULL,
+    salt                  BYTEA NOT NULL,
+    iteration_count       INTEGER NOT NULL,
+    last_presence         TEXT NOT NULL,
+    last_presence_at      TIMESTAMP WITH TIME ZONE NOT NULL,
+    updated_at            TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    created_at            TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
 );
 
 SELECT enable_updated_at('users');

--- a/storage/memory/user_test.go
+++ b/storage/memory/user_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestMemoryStorage_InsertUser(t *testing.T) {
-	u := model.User{Username: "ortuman", Password: "1234"}
+	u := model.User{Username: "ortuman", PasswordScramSHA1: []byte("sha1")}
 	s := NewUser()
 	EnableMockedError()
 	err := s.UpsertUser(context.Background(), &u)
@@ -36,7 +36,7 @@ func TestMemoryStorage_UserExists(t *testing.T) {
 }
 
 func TestMemoryStorage_FetchUser(t *testing.T) {
-	u := model.User{Username: "ortuman", Password: "1234"}
+	u := model.User{Username: "ortuman", PasswordScramSHA1: []byte("sha1")}
 	s := NewUser()
 	_ = s.UpsertUser(context.Background(), &u)
 
@@ -53,7 +53,7 @@ func TestMemoryStorage_FetchUser(t *testing.T) {
 }
 
 func TestMemoryStorage_DeleteUser(t *testing.T) {
-	u := model.User{Username: "ortuman", Password: "1234"}
+	u := model.User{Username: "ortuman", PasswordScramSHA1: []byte("sha1")}
 	s := NewUser()
 	_ = s.UpsertUser(context.Background(), &u)
 

--- a/storage/pgsql/user_test.go
+++ b/storage/pgsql/user_test.go
@@ -23,11 +23,18 @@ func TestInsertUser(t *testing.T) {
 	to, _ := jid.NewWithString("ortuman@jackal.im", true)
 	p := xmpp.NewPresence(from, to, xmpp.UnavailableType)
 
-	user := model.User{Username: "ortuman", Password: "1234", LastPresence: p}
+	user := model.User{
+		Username:            "ortuman",
+		PasswordScramSHA1:   []byte("sha1"),
+		PasswordScramSHA256: []byte("sha256"),
+		Salt:                []byte("salt"),
+		IterationCount:      10000,
+		LastPresence:        p,
+	}
 
 	s, mock := newUserMock()
 	mock.ExpectExec("INSERT INTO users (.+) ON CONFLICT (.+) DO UPDATE SET (.+)").
-		WithArgs(user.Username, user.Password, user.LastPresence.String()).
+		WithArgs(user.Username, user.PasswordScramSHA1, user.PasswordScramSHA256, user.Salt, user.IterationCount, user.LastPresence.String()).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	err := s.UpsertUser(context.Background(), &user)
@@ -36,7 +43,7 @@ func TestInsertUser(t *testing.T) {
 
 	s, mock = newUserMock()
 	mock.ExpectExec("INSERT INTO users (.+) ON CONFLICT (.+) DO UPDATE SET (.+)").
-		WithArgs(user.Username, user.Password, user.LastPresence.String()).
+		WithArgs(user.Username, user.PasswordScramSHA1, user.PasswordScramSHA256, user.Salt, user.IterationCount, user.LastPresence.String()).
 		WillReturnError(errMocked)
 
 	err = s.UpsertUser(context.Background(), &user)
@@ -81,7 +88,7 @@ func TestFetchUser(t *testing.T) {
 	to, _ := jid.NewWithString("ortuman@jackal.im", true)
 	p := xmpp.NewPresence(from, to, xmpp.UnavailableType)
 
-	var userColumns = []string{"username", "password", "last_presence", "last_presence_at"}
+	var userColumns = []string{"username", "password_scram_sha1", "password_scram_sha256", "salt", "iteration_count", "last_presence", "last_presence_at"}
 
 	s, mock := newUserMock()
 	mock.ExpectQuery("SELECT (.+) FROM users (.+)").
@@ -95,7 +102,7 @@ func TestFetchUser(t *testing.T) {
 	s, mock = newUserMock()
 	mock.ExpectQuery("SELECT (.+) FROM users (.+)").
 		WithArgs("ortuman").
-		WillReturnRows(sqlmock.NewRows(userColumns).AddRow("ortuman", "1234", p.String(), time.Now()))
+		WillReturnRows(sqlmock.NewRows(userColumns).AddRow("ortuman", "sha1", "sha256", "salt", 10000, p.String(), time.Now()))
 	_, err := s.FetchUser(context.Background(), "ortuman")
 	require.Nil(t, mock.ExpectationsWereMet())
 	require.Nil(t, err)


### PR DESCRIPTION
I do not use MySQL, so I have only tested this with PostgreSQL. This PR does not include any mechanism for migrating existing installs to the new schema or updating existing passwords.