### PR TITLE
Fix broken SCRAM auth

### DIFF
--- a/auth/scram.go
+++ b/auth/scram.go
@@ -291,12 +291,15 @@ func (s *Scram) parseParameters(str string) error {
 	}
 	gs2BindFlag := sp[0]
 
+	// https://tools.ietf.org/html/rfc5801#section-5
 	switch gs2BindFlag {
-	case "y":
+	case "p":
+		// Channel binding is supported and required.
 		if !s.usesCb {
 			return ErrSASLNotAuthorized
 		}
-	case "n":
+	case "n", "y":
+		// Channel binding is not supported, or is supported but is not required.
 		break
 	default:
 		if !strings.HasPrefix(gs2BindFlag, "p=") {

--- a/c2s/in.go
+++ b/c2s/in.go
@@ -189,6 +189,7 @@ func (s *inStream) Disconnect(ctx context.Context, err error) {
 
 func (s *inStream) initializeAuthenticators() {
 	tr := s.tr
+	hasChannelBinding := len(tr.ChannelBindingBytes(transport.TLSUnique)) > 0
 	var authenticators []auth.Authenticator
 	for _, a := range s.cfg.sasl {
 		switch a {
@@ -200,15 +201,21 @@ func (s *inStream) initializeAuthenticators() {
 
 		case "scram_sha_1":
 			authenticators = append(authenticators, auth.NewScram(s, tr, auth.ScramSHA1, false, s.userRep))
-			authenticators = append(authenticators, auth.NewScram(s, tr, auth.ScramSHA1, true, s.userRep))
+			if hasChannelBinding {
+				authenticators = append(authenticators, auth.NewScram(s, tr, auth.ScramSHA1, true, s.userRep))
+			}
 
 		case "scram_sha_256":
 			authenticators = append(authenticators, auth.NewScram(s, tr, auth.ScramSHA256, false, s.userRep))
-			authenticators = append(authenticators, auth.NewScram(s, tr, auth.ScramSHA256, true, s.userRep))
+			if hasChannelBinding {
+				authenticators = append(authenticators, auth.NewScram(s, tr, auth.ScramSHA256, true, s.userRep))
+			}
 
 		case "scram_sha_512":
 			authenticators = append(authenticators, auth.NewScram(s, tr, auth.ScramSHA512, false, s.userRep))
-			authenticators = append(authenticators, auth.NewScram(s, tr, auth.ScramSHA512, true, s.userRep))
+			if hasChannelBinding {
+				authenticators = append(authenticators, auth.NewScram(s, tr, auth.ScramSHA512, true, s.userRep))
+			}
 		}
 	}
 	s.authenticators = authenticators


### PR DESCRIPTION
While attempting to log in using a client that supports both SCRAM-SHA-1
and SCRAM-SHA-1-PLUS I noticed that login was failing unless I disabled
every mechanism except PLAIN. After futher investigation, I noticed that
the client was using TLS 1.3, which does not support the tls-unique
mechanism used by Jackals channel binding implementation. This would
also have been the case if I had been trying to do TLS resumption
without the TLS master-secret fix.

To fix this I altered the channel binding code to only advertise the
-PLUS variants if the TLS unique data is available. However, even with
the fix login was still failing. It turns out there was also a bug where
the value of the GS2 header was treating clients that report that
channel binding is supported, but not required, as if it was supported
and required. I also added a fix for this, and a comment pointing at the
definitions of the channel binding headers.