### PR TITLE
Rework Makefile to fix bugs and respect LDFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,42 +1,67 @@
+.POSIX:
+.SUFFIXES:
+
+GOFILES!=find . -name '*.go'
+
+GOLDFLAGS =-s -w -extldflags $(LDFLAGS)
+
+.PHONY: install
 install:
 	@go install -ldflags="-s -w" github.com/ortuman/jackal
 
+.PHONY: install-tools
 install-tools:
-	@go get -u \
+	@env GO111MODULE=off go get -u \
 		golang.org/x/lint/golint \
 		golang.org/x/tools/cmd/goimports
 
+.PHONY: fmt
 fmt: install-tools
 	@echo "Checking go files format..."
 	@GOIMP=$$(for f in $$(find . -type f -name "*.go" ! -path "./.cache/*" ! -path "./vendor/*" ! -name "bindata.go") ; do \
-    		goimports -l $$f ; \
-    	done) && echo $$GOIMP && test -z "$$GOIMP"
+		goimports -l $$f ; \
+		done) && echo $$GOIMP && test -z "$$GOIMP"
 
-build:
+go.sum: $(GOFILES) go.mod
+	go mod tidy
+
+jackal: $(GOFILES) go.mod go.sum
 	@echo "Building binary..."
-	@go build -ldflags="-s -w"
+	@go build\
+		-trimpath \
+		-o $@ \
+		-ldflags "$(GOLDFLAGS)"
 
+.PHONY: build
+build: jackal
+
+.PHONY: test
 test:
 	@echo "Running tests..."
 	@go test -race $$(go list ./...)
 
+.PHONY: coverate
 coverage:
 	@echo "Generating coverage profile..."
 	@go test -race -coverprofile=coverage.txt -covermode=atomic $$(go list ./...)
 
+.PHONY: vet
 vet:
 	@echo "Searching for buggy code..."
 	@go vet $$(go list ./...)
 
+.PHONY: lint
 lint: install-tools
 	@echo "Running linter..."
 	@golint $$(go list ./...)
 
+.PHONY: dockerimage
 dockerimage:
 	@echo "Building binary..."
 	@env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w"
 	@echo "Building docker image..."
 	@docker build -f dockerfiles/Dockerfile -t ortuman/jackal .
 
+.PHONY: clean
 clean:
 	@go clean

--- a/c2s/in_test.go
+++ b/c2s/in_test.go
@@ -7,7 +7,6 @@ package c2s
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -222,8 +221,6 @@ func TestStream_SendIQ(t *testing.T) {
 	iq.AppendElement(xmpp.NewElementNamespace("query", "jabber:iq:roster"))
 
 	_, _ = conn.inboundWrite([]byte(iq.String()))
-
-	fmt.Println("4")
 
 	elem := conn.outboundRead()
 	require.Equal(t, "iq", elem.Name())

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/Masterminds/squirrel v1.1.0
 	github.com/go-sql-driver/mysql v1.4.1
 	github.com/google/uuid v1.1.1
-	github.com/gorilla/websocket v1.4.1
 	github.com/lib/pq v1.3.0
 	github.com/mattn/go-sqlite3 v1.10.0 // indirect
 	github.com/pborman/uuid v1.2.0
@@ -19,5 +18,4 @@ require (
 	golang.org/x/text v0.3.0
 	google.golang.org/appengine v1.3.0 // indirect
 	gopkg.in/yaml.v2 v2.2.7
-
 )

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,6 @@ github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/gorilla/websocket v1.4.1 h1:q7AeDBpnBk8AogcD4DSag/Ukw/KV+YhzLj2bP5HvKCM=
-github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 h1:SOEGU9fKiNWd/HOJuq6+3iTQz8KNCLtVX6idSoTLdUw=
 github.com/lann/builder v0.0.0-20180802200727-47ae307949d0/go.mod h1:dXGbAdH5GtBTC4WfIxhKZfyBF/HBFgRZSWwZ9g/He9o=
 github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 h1:P6pPBnrTSX3DEVR4fDembhRWSsG5rVo6hYhAB/ADZrk=


### PR DESCRIPTION
Previously every rule in the makefile was phony, but none were declared
as such. This meant that eg. if a file called "clean" or "build" was
created, Make would think the rules with the same names referred to
those files and may think they were up to date and refuse to run the
recipe. Marking these rules as phony ensures that they are always
considered out of date and will always be run.

This also adds the .POSIX and .SUFFIXES targets to remove pre-defined C
suffix rules (its not likely that this would ever cause problems, but
it's nice to start from a clean slate) and use POSIX compatible behavior
(GNU Make is particularly bad about this, so using .POSIX normalizes the
behavior a tiny bit between GNU Make and NetBSD make like I use).

Finally, the build rule has been marked phony and now just depends on
the jackal (non-phony) rule which ensures that go.mod gets run when
necessary, and is rebuilt any time a *.go file changes. The build has
also been updated to trim paths so you don't wind up with release
binaries that include your home directory path in them for debugging
purposes and respect external LDFLAGS to make it easier for package
managers to spit out a position independent executable, or make other
changes that might be required by their operating system or distros
packaging procedures.