### PR TITLE
Support tls-exporter channel binding type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## jackal - main / unreleased
 
+* [ENHANCEMENT] Re-enable TLS 1.3 channel binding during auth using [RFC 9266](https://www.rfc-editor.org/rfc/rfc9266).
+
 ## 0.61.0 (2022/06/06)
 
 * [ENHANCEMENT] Helm: added support for cloud LB. [237](https://github.com/ortuman/jackal/pull/237) 

--- a/pkg/auth/scram.go
+++ b/pkg/auth/scram.go
@@ -357,6 +357,8 @@ func (s *Scram) getCBindInputString() string {
 		switch s.params.cbMechanism {
 		case "tls-unique":
 			buf.Write(s.tr.ChannelBindingBytes(transport.TLSUnique))
+		case "tls-exporter":
+			buf.Write(s.tr.ChannelBindingBytes(transport.TLSExporter))
 		}
 	}
 	return base64.StdEncoding.EncodeToString(buf.Bytes())

--- a/pkg/c2s/in.go
+++ b/pkg/c2s/in.go
@@ -765,7 +765,7 @@ func (s *inC2S) unauthenticatedFeatures() []stravaganza.Element {
 		sb.WithAttribute(stravaganza.Namespace, saslNamespace)
 		for _, authenticator := range s.authSt.authenticators {
 			if authenticator.UsesChannelBinding() && !supportsCb {
-				continue // transport doesn't support channel binding (eg. TLS 1.3)
+				continue // transport doesn't support channel binding
 			}
 			sb.WithChild(
 				stravaganza.NewBuilder("mechanism").

--- a/pkg/transport/socket_test.go
+++ b/pkg/transport/socket_test.go
@@ -87,6 +87,7 @@ func TestSocket(t *testing.T) {
 
 	require.Nil(t, st2.ChannelBindingBytes(ChannelBindingMechanism(99)))
 	require.Nil(t, st2.ChannelBindingBytes(TLSUnique))
+	require.Nil(t, st2.ChannelBindingBytes(TLSExporter))
 
 	_ = st.Close()
 	require.True(t, conn.closed)

--- a/pkg/transport/transport.go
+++ b/pkg/transport/transport.go
@@ -47,6 +47,8 @@ type ChannelBindingMechanism int
 const (
 	// TLSUnique represents 'tls-unique' channel binding mechanism.
 	TLSUnique ChannelBindingMechanism = iota
+	// TLSExporter represents the 'tls-exporter' channel binding mechanism.
+	TLSExporter
 )
 
 // Transport represents a stream transport mechanism.


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added

### Affected core subsystem(s)

- `pkg/c2s`
- `pkg/auth`
- `pkg/transport`

### Description of change

This adds support for the `tls-exporter` channel binding type defined in the upcoming [RFC 9266](https://www.rfc-editor.org/authors/rfc9266.html) (the RFC is not yet published, but at this stage only last minute editorial changes can be made and it is scheduled for publication). This enables channel binding support for TLS >= 1.3.

**EDIT:** The RFC has been [published](https://www.rfc-editor.org/info/rfc9266).
