### PR TITLE
scripts: do not install utilities on users system

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,8 @@ require (
 	google.golang.org/protobuf v1.28.0
 )
 
+require google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.2.0
+
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f // indirect

--- a/go.sum
+++ b/go.sum
@@ -626,6 +626,8 @@ google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3Iji
 google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=
 google.golang.org/grpc v1.38.0 h1:/9BgsAsa5nWe26HqOlvlgJnqBuktYOLCgjCPqsa56W0=
 google.golang.org/grpc v1.38.0/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQdJfM=
+google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.2.0 h1:TLkBREm4nIsEcexnCjgQd5GQWaHcqMzwQV0TX9pq8S0=
+google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.2.0/go.mod h1:DNq5QpG7LJqD2AamLZ7zvKE0DEpVl2BSEVjFycAAjRY=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=
@@ -637,6 +639,7 @@ google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpAD
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.28.0 h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscLw=
 google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=

--- a/scripts/genproto.sh
+++ b/scripts/genproto.sh
@@ -19,9 +19,18 @@ FILES=(
   "model/v1/roster.proto"
 )
 
+# Create the vendor/ dir for protobuf files to import from, and clean it up at
+# the end of the script (regardless of the exit status).
+# We move the vendor directory to a new name to avoid "go run" trying to use it.
+function cleanup {
+	rm -rf ./tmp_vendor
+}
+trap cleanup EXIT
+go mod vendor -o tmp_vendor
+
 for file in "${FILES[@]}"; do
-  PATH="$(pwd)/scripts:$PATH" protoc \
-    --proto_path=${GOPATH}/src \
+  PATH="$PWD/scripts:$PATH" protoc \
+    --proto_path=./tmp_vendor \
     --proto_path=. \
     --go_out=. \
     --go-grpc_out=. \

--- a/scripts/genproto.sh
+++ b/scripts/genproto.sh
@@ -8,9 +8,6 @@ if ! [[ "$0" =~ scripts/genproto.sh ]]; then
 	exit 255
 fi
 
-go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.26
-go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.1
-
 FILES=(
   "admin/v1/users.proto"
   "c2s/v1/resourceinfo.proto"
@@ -23,7 +20,7 @@ FILES=(
 )
 
 for file in "${FILES[@]}"; do
-  protoc \
+  PATH="$(pwd)/scripts:$PATH" protoc \
     --proto_path=${GOPATH}/src \
     --proto_path=. \
     --go_out=. \

--- a/scripts/protoc-gen-go
+++ b/scripts/protoc-gen-go
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+go run google.golang.org/protobuf/cmd/protoc-gen-go

--- a/scripts/protoc-gen-go-grpc
+++ b/scripts/protoc-gen-go-grpc
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+go run google.golang.org/grpc/cmd/protoc-gen-go-grpc

--- a/tools.go
+++ b/tools.go
@@ -1,0 +1,7 @@
+//go:build tools
+
+package main
+
+import (
+	_ "google.golang.org/grpc/cmd/protoc-gen-go-grpc"
+)


### PR DESCRIPTION
Previously the genproto script would pollute the users $GOBIN with a
specific version of two tools for generating protobuf files, overwriting
the users existing versions if they already had these tools installed.
This patch depends on those tools in go.mod so that they can be built,
downloaded, and used with go run and don't need to be installed on the
users system. As a bonus, all versioning information is now in go.mod
instead of spread over go.mod and a script.

I can't really test this locally (as the script also appears to operate in GOPATH mode which hasn't been used for a while).