### PR TITLE
Rework makefile to enable incremental compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,18 @@
+.POSIX:
+.SILENT:
 .PHONY: check fmt vet lint generate test proto build install installctl push-dockerimage
+
+GOFILES!=find . -name '*.go'
+GOLDFLAGS =-s -w -extldflags $(LDFLAGS)
+
+jackal: $(GOFILES) go.mod go.sum
+	CGO_ENABLED=0 go build -tags netgo -ldflags "$(GOLDFLAGS)" -o "$@" ./cmd/jackal
+
+jackalctl: $(GOFILES) go.mod go.sum
+	CGO_ENABLED=0 go build -tags netgo -ldflags "$(GOLDFLAGS)" -o "$@" ./cmd/jackalctl
+
+go.sum: $(GOFILES) go.mod
+	go mod tidy
 
 generate:
 	@echo "Generating mock files..."
@@ -26,9 +40,8 @@ proto:
 	@echo "Generating proto code..."
 	@bash scripts/genproto.sh
 
-build:
+build: jackal
 	@echo "Compiling jackal binary..."
-	@bash scripts/compile.sh
 
 install:
 	@echo "Installing jackal binary..."

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-set -eufo pipefail
-
-command -v go >/dev/null 2>&1 || { echo 'Please install go or use image that has it'; exit 1; }
-
-CGO_ENABLED=0 go build -a -tags netgo \
-  -ldflags "-s -w" -o "jackal" "github.com/ortuman/jackal/cmd/jackal"


### PR DESCRIPTION
The history appears to have been changed at some point and #118 got dropped. This PR more or less re-creates it on top of the new makefile. Specifically, it adds non-phony targets for `jackal` and `jackalctl` that can be used to rebuild the tools only when build files change. This could be done for the various proto files too to improve the incremental compilation process further, but as discussed in other issues I really don't understand the protobuf build process very well so I thought I'd keep it simple at first until I was sure you'd even want these changes; no pressure, of course.