### PR TITLE
transport: limit writer buffer size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [ENHANCEMENT] Re-enable TLS 1.3 channel binding during auth using [RFC 9266](https://www.rfc-editor.org/rfc/rfc9266).
 * [ENHANCEMENT] hook: include propagated context into execution parameter. [249](https://github.com/ortuman/jackal/pull/249)
+* [ENHANCEMENT] transport: limit writer buffer size [#251](https://github.com/ortuman/jackal/pull/251)
 
 ## 0.61.0 (2022/06/06)
 


### PR DESCRIPTION
Signed-off-by: Miguel Ángel Ortuño <ortuman@gmail.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Affected core subsystem(s)
<!-- Please provide affected core subsystem(s). -->

transport

### Description of change
<!-- Please provide a description of the change here. -->

Limit write buffer size on socket transport type.