### PR TITLE
chore: remove refs to deprecated io/ioutil

### DIFF
--- a/pkg/transport/compress/zlib_test.go
+++ b/pkg/transport/compress/zlib_test.go
@@ -16,7 +16,7 @@ package compress
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -94,7 +94,7 @@ func TestZlibInflate(t *testing.T) {
 		rBuf.Reset()
 		rBuf.Write(tc.input)
 		compressor := NewZlibCompressor(rBuf, nil, tc.level)
-		b, _ := ioutil.ReadAll(compressor)
+		b, _ := io.ReadAll(compressor)
 		require.Equal(t, tc.output, string(b))
 	}
 }
@@ -109,6 +109,6 @@ func TestInvalidInflate(t *testing.T) {
 	rBuf := new(bytes.Buffer)
 	rBuf.Write([]byte("this is garbage!"))
 	compressor := NewZlibCompressor(rBuf, nil, DefaultCompression)
-	_, err := ioutil.ReadAll(compressor)
+	_, err := io.ReadAll(compressor)
 	require.NotNil(t, err)
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Affected core subsystem(s)
<!-- Please provide affected core subsystem(s). -->

### Description of change
<!-- Please provide a description of the change here. -->
"io/ioutil" has been deprecated since Go 1.19: As of Go 1.16